### PR TITLE
Add info.rkt

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,0 +1,5 @@
+#lang info.rkt
+
+(define collection "rasm")
+(define deps '("base" "typed-racket-lib"))
+(define license '(MIT))

--- a/info.rkt
+++ b/info.rkt
@@ -3,3 +3,6 @@
 (define collection "rasm")
 (define deps '("base" "typed-racket-lib"))
 (define license '(MIT))
+(define racket-launcher-libraries '("compiler.rkt"))
+(define racket-launcher-names '("rasm-compile"))
+(define raco-commands '(("rasm-compile" rasm/compiler "A Racket to WASM compiler." #f)))


### PR DESCRIPTION
Hi!

I'm trying using this library but I hope to use it with `raco`. An info.rkt is created so that we can use it with a `raco rasm-compile <filename>` command after installing this library using `raco pkg install`. In addition to adding a `raco` command, a launcher called `rasm-compile` will also be generated during the period of installing this library.